### PR TITLE
Add some Gradle 6 shim support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ project(':artifactural9') {
     }
 }
 
+def gradleModuleSourcesPath = Paths.get("org", "gradle", "internal", "component", "model", "ModuleSources.class")
 def gradleRepositoryAdapterPath = Paths.get("com", "amadornes", "artifactural", "gradle", "GradleRepositoryAdapter.class")
 def classesDirs = sourceSets.gradlecomp.output.classesDirs.getFiles().first().toPath()
 
@@ -214,6 +215,7 @@ jar {
     from sourceSets.shared.output
     from(sourceSets.gradlecomp.output) {
         exclude gradleRepositoryAdapterPath.toString()
+        exclude gradleModuleSourcesPath.toString()
     }
 
     from patchConstructor.outputs

--- a/src/gradlecomp/java/com/amadornes/artifactural/gradle/GradleRepositoryAdapter.java
+++ b/src/gradlecomp/java/com/amadornes/artifactural/gradle/GradleRepositoryAdapter.java
@@ -31,6 +31,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepositoryAccess;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -55,6 +56,8 @@ import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.nativeintegration.services.FileSystems;
+import org.gradle.internal.reflect.DirectInstantiator;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -172,6 +175,12 @@ public class GradleRepositoryAdapter extends AbstractArtifactRepository implemen
             @Override public InstantiatingAction<ComponentMetadataSupplierDetails> getComponentMetadataSupplier() { return resolver.getComponentMetadataSupplier(); }
             @Override public boolean isDynamicResolveMode() { return resolver.isDynamicResolveMode(); }
             @Override public boolean isLocal() { return resolver.isLocal(); }
+            // Bytecode to implement added changes in Gradle 6.6.0 that expressly adds two methods
+            // to the interface without a default implementation because #internals
+            public void setComponentResolvers(ComponentResolvers resolver) { }
+            public Instantiator getComponentMetadataInstantiator() {
+                return resolver.getComponentMetadataInstantiator();
+            }
 
             private ModuleComponentRepositoryAccess wrap(ModuleComponentRepositoryAccess delegate) {
                 return new ModuleComponentRepositoryAccess() {

--- a/src/gradlecomp/java/org/gradle/internal/component/model/ModuleSources.java
+++ b/src/gradlecomp/java/org/gradle/internal/component/model/ModuleSources.java
@@ -1,0 +1,18 @@
+package org.gradle.internal.component.model;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public interface ModuleSources {
+
+    <T extends ModuleSource> Optional<T> getSource(Class<T> sourceType);
+
+    void withSources(Consumer<ModuleSource> consumer);
+
+    default <T extends ModuleSource, R> R withSource(Class<T> sourceType, Function<Optional<T>, R> action) {
+        return action.apply(getSource(sourceType));
+    }
+
+    int size();
+}


### PR DESCRIPTION
**Artifactural** | [ForgeGradle](https://github.com/MinecraftForge/ForgeGradle/pull/722)

More hack fixes that allow Gradle 6 support with references to the specific commits in gradle the modifications/workarounds are designed for.

This is in part to potentially allow for ForgeGradle 3 to "work" in a Gradle 6 environment.