### PR TITLE
Draft: Implement a basic artifact attributes API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ tasks.withType(JavaCompile).configureEach {
 tasks.register('transformJar', JarTransformationTask) {
     addTransformer('net/minecraftforge/artifactural/gradle/GradleRepositoryAdapter') {
         it.methods.find {
-            it.name == '<init>' && it.desc == '(Lnet/minecraftforge/artifactural/api/repository/Repository;Lorg/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository;)V'
+            it.name == '<init>' && it.desc == '(Lorg/gradle/api/artifacts/ConfigurationContainer;Lnet/minecraftforge/artifactural/api/repository/Repository;Lorg/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository;)V'
         }?.tap {
             it.instructions.find {
                 it instanceof InsnNode && it.opcode == Opcodes.ACONST_NULL
@@ -258,6 +258,6 @@ publishing {
     }
 }
 
-changelog {
-    from '3.0'
-}
+//changelog {
+//    from '3.0'
+//}

--- a/header.txt
+++ b/header.txt
@@ -1,5 +1,5 @@
 Artifactural
-Copyright (c) 2018-2021.
+Copyright (c) 2018-2024.
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/Artifact.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/Artifact.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,12 +19,12 @@
 
 package net.minecraftforge.artifactural.api.artifact;
 
+import net.minecraftforge.artifactural.api.cache.ArtifactCache;
+import net.minecraftforge.artifactural.api.transform.ArtifactTransformer;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-
-import net.minecraftforge.artifactural.api.cache.ArtifactCache;
-import net.minecraftforge.artifactural.api.transform.ArtifactTransformer;
 
 public interface Artifact {
 
@@ -46,6 +46,10 @@ public interface Artifact {
 
     default Artifact.Cached optionallyCache(ArtifactCache cache) {
         return this instanceof Artifact.Cached ? (Artifact.Cached) this : cache(cache);
+    }
+
+    default ArtifactAttributeCollection getAttributes() {
+        return getIdentifier().getAttributes();
     }
 
     boolean isPresent();

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactAttribute.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactAttribute.java
@@ -20,6 +20,10 @@
 package net.minecraftforge.artifactural.api.artifact;
 
 public interface ArtifactAttribute<T> {
+    static <T> ArtifactAttribute<T> create(String name, Class<T> type) {
+        return new SimpleArtifactAttribute<>(name, type);
+    }
+
     String getName();
 
     Class<T> getType();

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactAttribute.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactAttribute.java
@@ -17,12 +17,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.artifactural.api.cache;
+package net.minecraftforge.artifactural.api.artifact;
 
-import net.minecraftforge.artifactural.api.artifact.Artifact;
+public interface ArtifactAttribute<T> {
+    String getName();
 
-public interface ArtifactCache {
-
-    Artifact.Cached store(Artifact artifact);
-
+    Class<T> getType();
 }

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactAttributeCollection.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactAttributeCollection.java
@@ -17,12 +17,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.artifactural.api.cache;
+package net.minecraftforge.artifactural.api.artifact;
 
-import net.minecraftforge.artifactural.api.artifact.Artifact;
+import java.util.Map.Entry;
+import java.util.Set;
 
-public interface ArtifactCache {
+public interface ArtifactAttributeCollection extends Iterable<Entry<ArtifactAttribute<?>, Object>> {
+    static ArtifactAttributeCollection empty() {
+        return Internal.NO_ATTRIBUTES;
+    }
 
-    Artifact.Cached store(Artifact artifact);
+    <T> T with(ArtifactAttribute<T> attribute, T value);
 
+    <T> T get(ArtifactAttribute<T> key);
+
+    Set<ArtifactAttribute<?>> keys();
 }

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactIdentifier.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactIdentifier.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -36,6 +36,8 @@ public interface ArtifactIdentifier {
     String getClassifier();
 
     String getExtension();
+
+    ArtifactAttributeCollection getAttributes();
 
     static Predicate<ArtifactIdentifier> groupMatches(String group) {
         return identifier -> identifier.getGroup().matches(group);

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactMetadata.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactMetadata.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactType.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/ArtifactType.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/Internal.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/Internal.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,11 +21,38 @@ package net.minecraftforge.artifactural.api.artifact;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import net.minecraftforge.artifactural.api.cache.ArtifactCache;
 import net.minecraftforge.artifactural.api.transform.ArtifactTransformer;
 
 final class Internal {
+
+    static final ArtifactAttributeCollection NO_ATTRIBUTES = new ArtifactAttributeCollection() {
+        @Override
+        public <T> T with(ArtifactAttribute<T> attribute, T value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T get(ArtifactAttribute<T> key) {
+            return null;
+        }
+
+        @Override
+        public Set<ArtifactAttribute<?>> keys() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Iterator<Entry<ArtifactAttribute<?>, Object>> iterator() {
+            return Collections.<Entry<ArtifactAttribute<?>, Object>>emptyList().iterator();
+        }
+    };
 
     static final ArtifactIdentifier NO_IDENTIFIER = new ArtifactIdentifier() {
 
@@ -59,6 +86,10 @@ final class Internal {
             return "NO_IDENTIFIER";
         }
 
+        @Override
+        public ArtifactAttributeCollection getAttributes() {
+            return NO_ATTRIBUTES;
+        }
     };
 
     static final Artifact NO_ARTIFACT = new Artifact.Cached() {

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/MissingArtifactException.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/MissingArtifactException.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/SimpleArtifactAttribute.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/SimpleArtifactAttribute.java
@@ -17,11 +17,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.artifactural.base.artifact;
+package net.minecraftforge.artifactural.api.artifact;
 
-import net.minecraftforge.artifactural.api.artifact.ArtifactAttribute;
-
-public class SimpleArtifactAttribute<T> implements ArtifactAttribute<T> {
+final class SimpleArtifactAttribute<T> implements ArtifactAttribute<T> {
     private final String name;
     private final Class<T> type;
 

--- a/src/api/java/net/minecraftforge/artifactural/api/artifact/Streamable.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/artifact/Streamable.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/java/net/minecraftforge/artifactural/api/repository/ArtifactProvider.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/repository/ArtifactProvider.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/java/net/minecraftforge/artifactural/api/repository/Repository.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/repository/Repository.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/api/java/net/minecraftforge/artifactural/api/transform/ArtifactTransformer.java
+++ b/src/api/java/net/minecraftforge/artifactural/api/transform/ArtifactTransformer.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/DependencyResolver.java
+++ b/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/DependencyResolver.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleArtifact.java
+++ b/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleArtifact.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleAttributeCollection.java
+++ b/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleAttributeCollection.java
@@ -19,7 +19,7 @@
 
 package net.minecraftforge.artifactural.gradle;
 
-import net.minecraftforge.artifactural.base.artifact.SimpleArtifactAttribute;
+import net.minecraftforge.artifactural.api.artifact.ArtifactAttribute;
 import net.minecraftforge.artifactural.base.artifact.SimpleAttributeCollection;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
@@ -27,7 +27,7 @@ import org.gradle.api.attributes.AttributeContainer;
 public class GradleAttributeCollection extends SimpleAttributeCollection {
     public GradleAttributeCollection(final AttributeContainer container) {
         for (Attribute<?> attribute : container.keySet()) {
-            values.put(new SimpleArtifactAttribute<>(attribute.getName(), attribute.getType()), container.getAttribute(attribute));
+            values.put(ArtifactAttribute.create(attribute.getName(), attribute.getType()), container.getAttribute(attribute));
         }
     }
 }

--- a/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleAttributeCollection.java
+++ b/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleAttributeCollection.java
@@ -17,12 +17,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.artifactural.api.cache;
+package net.minecraftforge.artifactural.gradle;
 
-import net.minecraftforge.artifactural.api.artifact.Artifact;
+import net.minecraftforge.artifactural.base.artifact.SimpleArtifactAttribute;
+import net.minecraftforge.artifactural.base.artifact.SimpleAttributeCollection;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 
-public interface ArtifactCache {
-
-    Artifact.Cached store(Artifact artifact);
-
+public class GradleAttributeCollection extends SimpleAttributeCollection {
+    public GradleAttributeCollection(final AttributeContainer container) {
+        for (Attribute<?> attribute : container.keySet()) {
+            values.put(new SimpleArtifactAttribute<>(attribute.getName(), attribute.getType()), container.getAttribute(attribute));
+        }
+    }
 }

--- a/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/ReflectionUtils.java
+++ b/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/ReflectionUtils.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/RepositoryContentUtils.java
+++ b/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/RepositoryContentUtils.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/artifact/ArtifactBase.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/artifact/ArtifactBase.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,10 +19,7 @@
 
 package net.minecraftforge.artifactural.base.artifact;
 
-import net.minecraftforge.artifactural.api.artifact.Artifact;
-import net.minecraftforge.artifactural.api.artifact.ArtifactIdentifier;
-import net.minecraftforge.artifactural.api.artifact.ArtifactMetadata;
-import net.minecraftforge.artifactural.api.artifact.ArtifactType;
+import net.minecraftforge.artifactural.api.artifact.*;
 import net.minecraftforge.artifactural.api.cache.ArtifactCache;
 import net.minecraftforge.artifactural.api.transform.ArtifactTransformer;
 
@@ -68,5 +65,4 @@ public abstract class ArtifactBase implements Artifact {
     public String toString() {
         return getClass().getSimpleName() + "(" + identifier + ", " + type +", " + metadata;
     }
-
 }

--- a/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleArtifactAttribute.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleArtifactAttribute.java
@@ -17,12 +17,26 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.artifactural.api.cache;
+package net.minecraftforge.artifactural.base.artifact;
 
-import net.minecraftforge.artifactural.api.artifact.Artifact;
+import net.minecraftforge.artifactural.api.artifact.ArtifactAttribute;
 
-public interface ArtifactCache {
+public class SimpleArtifactAttribute<T> implements ArtifactAttribute<T> {
+    private final String name;
+    private final Class<T> type;
 
-    Artifact.Cached store(Artifact artifact);
+    public SimpleArtifactAttribute(final String name, final Class<T> type) {
+        this.name = name;
+        this.type = type;
+    }
 
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Class<T> getType() {
+        return type;
+    }
 }

--- a/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleArtifactIdentifier.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleArtifactIdentifier.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,18 +19,26 @@
 
 package net.minecraftforge.artifactural.base.artifact;
 
+import net.minecraftforge.artifactural.api.artifact.ArtifactAttributeCollection;
 import net.minecraftforge.artifactural.api.artifact.ArtifactIdentifier;
 
 public class SimpleArtifactIdentifier implements ArtifactIdentifier {
 
     private final String group, name, version, classifier, extension;
+    private final ArtifactAttributeCollection attributes;
 
-    public SimpleArtifactIdentifier(String group, String name, String version, String classifier, String extension) {
+    public SimpleArtifactIdentifier(String group,
+                                    String name,
+                                    String version,
+                                    String classifier,
+                                    String extension,
+                                    ArtifactAttributeCollection attributes) {
         this.group = group;
         this.name = name;
         this.version = version;
         this.classifier = classifier;
         this.extension = extension;
+        this.attributes = attributes;
     }
 
     @Override
@@ -56,6 +64,11 @@ public class SimpleArtifactIdentifier implements ArtifactIdentifier {
     @Override
     public String getExtension() {
         return extension;
+    }
+
+    @Override
+    public ArtifactAttributeCollection getAttributes() {
+        return attributes;
     }
 
     @Override

--- a/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleArtifactMetadata.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleArtifactMetadata.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleAttributeCollection.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/artifact/SimpleAttributeCollection.java
@@ -1,0 +1,54 @@
+/*
+ * Artifactural
+ * Copyright (c) 2018-2024.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.artifactural.base.artifact;
+
+import net.minecraftforge.artifactural.api.artifact.ArtifactAttribute;
+import net.minecraftforge.artifactural.api.artifact.ArtifactAttributeCollection;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class SimpleAttributeCollection implements ArtifactAttributeCollection {
+    protected final HashMap<ArtifactAttribute<?>, Object> values = new HashMap<>();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(ArtifactAttribute<T> key) {
+        return (T) values.get(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T with(ArtifactAttribute<T> attribute, T value) {
+        return (T) values.put(attribute, value);
+    }
+
+    @Override
+    public Set<ArtifactAttribute<?>> keys() {
+        return values.keySet();
+    }
+
+    @Override
+    public Iterator<Entry<ArtifactAttribute<?>, Object>> iterator() {
+        return values.entrySet().iterator();
+    }
+}

--- a/src/shared/java/net/minecraftforge/artifactural/base/artifact/StreamableArtifact.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/artifact/StreamableArtifact.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/cache/ArtifactCacheBase.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/cache/ArtifactCacheBase.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/cache/LocatedArtifactCache.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/cache/LocatedArtifactCache.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/repository/ArtifactProviderBuilder.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/repository/ArtifactProviderBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/repository/SimpleRepository.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/repository/SimpleRepository.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/util/HashFunction.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/util/HashFunction.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/shared/java/net/minecraftforge/artifactural/base/util/PatternReplace.java
+++ b/src/shared/java/net/minecraftforge/artifactural/base/util/PatternReplace.java
@@ -1,6 +1,6 @@
 /*
  * Artifactural
- * Copyright (c) 2018-2021.
+ * Copyright (c) 2018-2024.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
This PR introduces a simple attribute system which allows attaching various "user-data" to artifact (identifiers).

This is going to be used in my PR for ForgeGradle which re-implement the deobfuscation repo artifact resolution using Gradle dependency attributes. Said dependency attributes are forwarded through the Artifactural API this way and allow matching repository artifacts based on dependency attributes.