### PR TITLE
Add Gradle 8.13 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,23 @@ tasks.register('transformJar', JarTransformationTask) {
     }
 
     addTransformer('net/minecraftforge/artifactural/gradle/GradleRepositoryAdapter$1$1') { clazz ->
+        // Gradle [8.13) - listModuleVersions add delegate call
+        {
+            final mtd = 'listModuleVersions'
+            final desc = '(Lorg/gradle/api/artifacts/component/ModuleComponentSelector;Lorg/gradle/internal/component/model/ComponentOverrideMetadata;Lorg/gradle/internal/resolve/result/BuildableModuleVersionListingResolveResult;)V'
+
+            clazz.methods.find { it.name == mtd && it.desc == desc }?.tap {
+                it.instructions.clear()
+                it.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0))
+                it.instructions.add(new FieldInsnNode(Opcodes.GETFIELD, 'net/minecraftforge/artifactural/gradle/GradleRepositoryAdapter$1$1', 'val$delegate', 'Lorg/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess;'))
+                it.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1))
+                it.instructions.add(new VarInsnNode(Opcodes.ALOAD, 2))
+                it.instructions.add(new VarInsnNode(Opcodes.ALOAD, 3))
+                it.instructions.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, 'org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess', 'listModuleVersions', '(Lorg/gradle/api/artifacts/component/ModuleComponentSelector;Lorg/gradle/internal/component/model/ComponentOverrideMetadata;Lorg/gradle/internal/resolve/result/BuildableModuleVersionListingResolveResult;)V'))
+                it.instructions.add(new InsnNode(Opcodes.RETURN))
+            }
+        }
+
         // Gradle [8.9) - resolveArtifactsWithType changed parameter types
         {
             final mtd = 'resolveArtifactsWithType'

--- a/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleRepositoryAdapter.java
+++ b/src/gradlecomp/java/net/minecraftforge/artifactural/gradle/GradleRepositoryAdapter.java
@@ -29,6 +29,7 @@ import net.minecraftforge.artifactural.base.cache.LocatedArtifactCache;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
@@ -254,6 +255,14 @@ public class GradleRepositoryAdapter extends AbstractArtifactRepository implemen
                     @Override
                     public void listModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
                         delegate.listModuleVersions(dependency, result);
+                    }
+
+                    // DO NOT TOUCH
+                    // Gradle 8.13 changed the first argument from ModuleDependencyMetadata to ModuleComponentSelector and added a new argument ComponentOverrideMetadata
+                    // https://github.com/gradle/gradle/commit/7f120d813df21b0d24f403180629f51ba0f8ee4c
+                    @SuppressWarnings("unused")
+                    public void listModuleVersions(ModuleComponentSelector selector, ComponentOverrideMetadata overrideMetadata, BuildableModuleVersionListingResolveResult result) {
+                        //ASM in build.gradle adds the delegate call
                     }
 
                     @Override


### PR DESCRIPTION
Adds support for Gradle 8.13 as they changed the parameter types of the listModuleVersions function.

Gradle commit: https://github.com/gradle/gradle/commit/7f120d813df21b0d24f403180629f51ba0f8ee4c